### PR TITLE
fix: remove family

### DIFF
--- a/pyblish_lite/model.py
+++ b/pyblish_lite/model.py
@@ -345,9 +345,6 @@ class Instance(Item):
         self.ids = []
         self.schema.update({
             IsChecked: "publish",
-
-            # Merge copy of both family and families data members
-            Families: "__families__",
         })
 
     def append(self, item):
@@ -367,10 +364,6 @@ class Instance(Item):
         item.data["_has_succeeded"] = False
         item.data["_has_failed"] = False
         item.data["_is_idle"] = True
-
-        # Merge `family` and `families` for backwards compatibility
-        item.data["__families__"] = ([item.data["family"]] +
-                                     item.data.get("families", []))
 
         return super(Instance, self).append(item)
 

--- a/pyblish_lite/window.py
+++ b/pyblish_lite/window.py
@@ -239,7 +239,7 @@ class Window(QtWidgets.QDialog):
          ____________________________
         |                            |
         | An Item              23 ms |
-        | - family                   |
+        | - families                   |
         |                            |
         |----------------------------|
         |                            |
@@ -838,11 +838,6 @@ class Window(QtWidgets.QDialog):
         for instance in self.controller.context:
             if instance.id not in models["instances"].ids:
                 models["instances"].append(instance)
-
-            family = instance.data["family"]
-            if family:
-                plugins_filter = self.data["models"]["filter"]
-                plugins_filter.add_inclusion(role="families", value=family)
 
             families = instance.data.get("families")
             if families:


### PR DESCRIPTION
Delete the obsolete "family" instance data attribute and use only "families".

BREAKING CHANGE: No more backward compatibility with plugins and tools using the "family" instance data attribute